### PR TITLE
Add `push_branch` entry to trigger map to fix workflow start errors

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -54,9 +54,10 @@ workflows:
     - deploy-to-bitrise-io@2: { }
 
 trigger_map:
+- push_branch: "*"
+  workflow: primary
 - pull_request_source_branch: "*"
   workflow: primary
-  pull_request_target_branch: main
 
 app:
   envs:


### PR DESCRIPTION
For unknown reasons, the workflow needs a `push_branch` entry in its config in order to successfully run on app.bitrise.io. This change mirrors [what is in the currently working iOS sample app](https://github.com/bitrise-io/Bitrise-iOS-Cocoapods-Sample/blob/1c096b808e32cde50dfa6a7fb6e89706352a5c87/bitrise.yml#L6-L10).

I've manually tested this by starting a build in the app.bitrise.io GUI pointing at this branch, and things work as expected. Build log is here: https://app.bitrise.io/build/c5717f9b-4d2b-49f5-95cc-956255331bd8